### PR TITLE
Add option to save chats

### DIFF
--- a/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
+++ b/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
@@ -73,6 +73,7 @@ private enum SGBoolSetting: String {
     case contextShowSaveMedia
     case contextShowMessageReplies
     case contextShowJson
+    case showSaveChatButton
     case disableScrollToNextChannel
     case disableScrollToNextTopic
     case disableChatSwipeOptions
@@ -296,6 +297,7 @@ private func SGControllerEntries(presentationData: PresentationData, callListSet
     entries.append(.toggle(id: id.count, section: .other, settingName: .forceEmojiTab, value: SGSimpleSettings.shared.forceEmojiTab, text: i18n("Settings.ForceEmojiTab", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .defaultEmojisFirst, value: SGSimpleSettings.shared.defaultEmojisFirst, text: i18n("Settings.DefaultEmojisFirst", lang), enabled: true))
     entries.append(.notice(id: id.count, section: .other, text: i18n("Settings.DefaultEmojisFirst.Notice", lang)))
+    entries.append(.toggle(id: id.count, section: .other, settingName: .showSaveChatButton, value: SGSimpleSettings.shared.showSaveChatButton, text: i18n("Settings.ShowSaveChatButton", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .hidePhoneInSettings, value: SGSimpleSettings.shared.hidePhoneInSettings, text: i18n("Settings.HidePhoneInSettingsUI", lang), enabled: true))
     entries.append(.notice(id: id.count, section: .other, text: i18n("Settings.HidePhoneInSettingsUI.Notice", lang)))
     
@@ -453,6 +455,8 @@ public func sgSettingsController(context: AccountContext/*, focusOnItemTag: Int?
             SGSimpleSettings.shared.stickerTimestamp = value
         case .contextShowJson:
             SGSimpleSettings.shared.contextShowJson = value
+        case .showSaveChatButton:
+            SGSimpleSettings.shared.showSaveChatButton = value
         case .hideRecordingButton:
             SGSimpleSettings.shared.hideRecordingButton = !value
         case .hideTabBar:

--- a/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
+++ b/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
@@ -109,6 +109,7 @@ public class SGSimpleSettings {
         case contextShowSaveMedia
         case contextShowMessageReplies
         case contextShowJson
+        case showSaveChatButton
         case disableScrollToNextChannel
         case disableScrollToNextTopic
         case disableChatSwipeOptions
@@ -244,6 +245,7 @@ public class SGSimpleSettings {
         Keys.contextShowSaveMedia.rawValue: true,
         Keys.contextShowMessageReplies.rawValue: true,
         Keys.contextShowJson.rawValue: false,
+        Keys.showSaveChatButton.rawValue: false,
         Keys.disableScrollToNextChannel.rawValue: false,
         Keys.disableScrollToNextTopic.rawValue: false,
         Keys.disableChatSwipeOptions.rawValue: false,
@@ -383,6 +385,9 @@ public class SGSimpleSettings {
     
     @UserDefault(key: Keys.contextShowJson.rawValue)
     public var contextShowJson: Bool
+
+    @UserDefault(key: Keys.showSaveChatButton.rawValue)
+    public var showSaveChatButton: Bool
     
     @UserDefault(key: Keys.disableScrollToNextChannel.rawValue)
     public var disableScrollToNextChannel: Bool

--- a/Swiftgram/SGStrings/Strings/ar.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/ar.lproj/SGLocalizable.strings
@@ -72,6 +72,7 @@
 "Settings.SendWithReturnKey" = "إرسال مع مفتاح \"العودة\"";
 "Settings.HidePhoneInSettingsUI" = "إخفاء الرقم من الإعدادات";
 "Settings.HidePhoneInSettingsUI.Notice" = "سيتم اخفاء رقمك من التطبيق فقط. لأخفاءهُ من المستخدمين الآخرين، يرجى استخدام إعدادات الخصوصية.";
+"Settings.ShowSaveChatButton" = "إظهار زر حفظ المحادثة";
 
 "PasscodeSettings.AutoLock.InFiveSeconds" = "إذا كان بعيدا لمدة 5 ثوان";
 

--- a/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
@@ -87,6 +87,7 @@
 "Settings.SendWithReturnKey" = "Send with \"return\" key";
 "Settings.HidePhoneInSettingsUI" = "Hide Phone in Settings";
 "Settings.HidePhoneInSettingsUI.Notice" = "This will only hide your phone number from the settings interface. To hide it from others, go to Privacy and Security.";
+"Settings.ShowSaveChatButton" = "Show Save Chat button";
 
 "PasscodeSettings.AutoLock.InFiveSeconds" = "If away for 5 seconds";
 

--- a/submodules/TelegramUI/Sources/ChatInterfaceStateContextMenus.swift
+++ b/submodules/TelegramUI/Sources/ChatInterfaceStateContextMenus.swift
@@ -38,6 +38,7 @@ import ChatControllerInteraction
 import ChatMessageItemCommon
 import ChatMessageItemView
 import ChatMessageBubbleItemNode
+import ActionSheetPeerItem
 import AdsInfoScreen
 import AdsReportScreen
  
@@ -1463,6 +1464,16 @@ func contextMenuForChatPresentationInterfaceState(chatPresentationInterfaceState
             actions.append(showJsonAction)
         } else {
             sgActions.append(showJsonAction)
+        }
+
+        let saveChatAction: ContextMenuItem = .action(ContextMenuActionItem(text: "Save Chat", icon: { theme in
+            return generateTintedImage(image: UIImage(bundleImageName: "Chat/Context Menu/Download"), color: theme.actionSheet.primaryTextColor)
+        }, action: { _, f in
+            presentSaveChatOptions(controllerInteraction: controllerInteraction, context: context, chatLocation: chatPresentationInterfaceState.chatLocation)
+            f(.default)
+        }))
+        if SGSimpleSettings.shared.showSaveChatButton {
+            sgActions.append(saveChatAction)
         }
         
         var threadId: Int64?
@@ -3004,9 +3015,32 @@ private final class ChatDeleteMessageContextItemNode: ASDisplayNode, ContextMenu
         self.setIsHighlighted(isHighlighted)
     }
     
-    func actionNode(at point: CGPoint) -> ContextActionNodeProtocol {
+func actionNode(at point: CGPoint) -> ContextActionNodeProtocol {
         return self
     }
+}
+
+private func presentSaveChatOptions(controllerInteraction: ChatControllerInteraction, context: AccountContext, chatLocation: ChatLocation) {
+    let presentationData = context.sharedContext.currentPresentationData.with { $0 }
+    let actionSheet = ActionSheetController(presentationData: presentationData)
+    var items: [ActionSheetItem] = []
+    items.append(ActionSheetButtonItem(title: "JSON", action: { [weak actionSheet] in
+        actionSheet?.dismissAnimated()
+        exportChat(context: context, chatLocation: chatLocation, format: "json")
+    }))
+    items.append(ActionSheetButtonItem(title: "HTML", action: { [weak actionSheet] in
+        actionSheet?.dismissAnimated()
+        exportChat(context: context, chatLocation: chatLocation, format: "html")
+    }))
+    items.append(ActionSheetButtonItem(title: presentationData.strings.Common_Cancel, color: .accent, font: .bold, action: { [weak actionSheet] in
+        actionSheet?.dismissAnimated()
+    }))
+    actionSheet.setItemGroups([ActionSheetItemGroup(items: items)])
+    controllerInteraction.presentController(actionSheet, nil)
+}
+
+private func exportChat(context: AccountContext, chatLocation: ChatLocation, format: String) {
+    // TODO: Implement chat export logic
 }
 
 final class ChatMessageAuthorContextItem: ContextMenuCustomItem {


### PR DESCRIPTION
## Summary
- add `showSaveChatButton` toggle and translations
- surface toggle in settings UI and chat menu
- scaffold chat export action with JSON/HTML choices

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689672412c488325b87c3141b8d9832c