### PR TITLE
Persist temporary document previews and enable sharing

### DIFF
--- a/submodules/TelegramUI/Sources/MediaPersistentStorage.swift
+++ b/submodules/TelegramUI/Sources/MediaPersistentStorage.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+private let persistentMediaFolder = "MediaPersistent"
+
+private func ensurePersistentDirectory() -> URL {
+    let fileManager = FileManager.default
+    let appSupport = try? fileManager.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    let directory = appSupport!.appendingPathComponent(persistentMediaFolder, isDirectory: true)
+    if !fileManager.fileExists(atPath: directory.path) {
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        try? directory.setResourceValues(resourceValues)
+    }
+    return directory
+}
+
+public func persistentMediaURL(fileName: String) -> URL {
+    return ensurePersistentDirectory().appendingPathComponent(fileName)
+}
+
+public func migrateToPersistentMedia(url: URL) -> URL {
+    let fileManager = FileManager.default
+    let destination = persistentMediaURL(fileName: url.lastPathComponent)
+    if fileManager.fileExists(atPath: url.path) {
+        if !fileManager.fileExists(atPath: destination.path) {
+            do {
+                try fileManager.moveItem(at: url, to: destination)
+            } catch {
+                _ = try? fileManager.removeItem(at: destination)
+                _ = try? fileManager.moveItem(at: url, to: destination)
+            }
+        } else {
+            _ = try? fileManager.removeItem(at: url)
+        }
+    }
+    return destination
+}


### PR DESCRIPTION
## Summary
- Add helper for storing media files persistently under Application Support/MediaPersistent
- Migrate previewed document files from temporary paths to persistent storage
- Expose a share button for previewed documents using UIActivityViewController

## Testing
- `swiftc -typecheck submodules/TelegramUI/Sources/DocumentPreviewController.swift submodules/TelegramUI/Sources/MediaPersistentStorage.swift` *(fails: no such module 'UIKit')*


------
https://chatgpt.com/codex/tasks/task_e_68967f9206a083259848834e326c0d17